### PR TITLE
Guard CUDA cache clearing in CPU disk benchmark

### DIFF
--- a/gpubench.py
+++ b/gpubench.py
@@ -363,7 +363,8 @@ def benchmark_cpu_to_disk_write(file_path, data_size_gb, reference_metrics):
 
         # Cleanup
         del cpu_data
-        torch.cuda.empty_cache()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
 
         # Optionally, remove the file after benchmarking
         if os.path.exists(file_path):


### PR DESCRIPTION
## Summary
- guard CUDA cache clearing in the CPU-to-disk write benchmark so it only runs when CUDA is available
- verified no other CPU-only helpers call torch.cuda.empty_cache

## Testing
- python gpubench.py --cpu-to-disk-write --num-iterations 1 --data-size-gb-cpu 0.01


------
https://chatgpt.com/codex/tasks/task_b_68d41dbbcbc08333bcfdf890d65b7cd2