### PR TITLE
Adjust section header formatting for category tables

### DIFF
--- a/gpubench.py
+++ b/gpubench.py
@@ -578,7 +578,11 @@ def _print_section_table(title, rows, headers, *, tablefmt='rounded_grid', colal
 
     display_headers = list(headers) if headers else []
     if display_headers:
-        display_headers[0] = f"{title} ▸ {display_headers[0]}"
+        first_header = display_headers[0]
+        if first_header.strip().lower() == "category":
+            display_headers[0] = title
+        else:
+            display_headers[0] = f"{title} ▸ {first_header}"
 
     print()
     table_str = _render_table(rows, display_headers, tablefmt, colalign)


### PR DESCRIPTION
## Summary
- stop appending the header label to section titles when the first column is named Category so the tables don't add redundant text

## Testing
- python -m compileall gpubench.py

------
https://chatgpt.com/codex/tasks/task_b_68d5d7a9ecd88333adc31481a175ab70